### PR TITLE
Update repo

### DIFF
--- a/scripts/compile_frontend.py
+++ b/scripts/compile_frontend.py
@@ -27,6 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import argparse
 import os
 import os.path as path
 import re
@@ -322,10 +323,17 @@ def generate_namespace_externs(modules_by_name):
 
 
 def main():
+    global protocol_externs_file
     errors_found = False
-    generate_protocol_externs.generate_protocol_externs(protocol_externs_file,
-                                                        path.join(inspector_path, 'browser_protocol.json'),
-                                                        path.join(v8_inspector_path, 'js_protocol.json'))
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--protocol-externs-file')
+    args, _ = parser.parse_known_args()
+    if args.protocol_externs_file:
+        protocol_externs_file = args.protocol_externs_file
+    else:
+        generate_protocol_externs.generate_protocol_externs(protocol_externs_file,
+                                                            path.join(inspector_path, 'browser_protocol.json'),
+                                                            path.join(v8_inspector_path, 'js_protocol.json'))
     loader = modular_build.DescriptorLoader(devtools_frontend_path)
     descriptors = loader.load_applications(application_descriptors)
     modules_by_name = descriptors.modules


### PR DESCRIPTION
…s file

This helps Lighthouse typecheck their code with DevTools.

Example usage:
python scripts/compile_frontend.py --protocol-externs-file /path/to/protocol_externs.js

You can get pre-generated protocol externs file here:
https://github.com/ChromeDevTools/devtools-protocol/blob/master/externs/protocol_externs.js

BUG=

Review-Url: https://codereview.chromium.org/2829233004
Cr-Original-Commit-Position: refs/heads/master@{#466723}
Cr-Mirrored-From: https://chromium.googlesource.com/chromium/src
Cr-Mirrored-Commit: b46c62594332f594eed74c827659c06a8f737462